### PR TITLE
Use `nixos-25.05` channel because of `rdkafka-2.10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750646418,
-        "narHash": "sha256-4UAN+W0Lp4xnUiHYXUXAPX18t+bn6c4Btry2RqM9JHY=",
+        "lastModified": 1752308619,
+        "narHash": "sha256-pzrVLKRQNPrii06Rm09Q0i0dq3wt2t2pciT/GNq5EZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1f426f65ac4e6bf808923eb6f8b8c2bfba3d18c5",
+        "rev": "650e572363c091045cdbc5b36b0f4c1f614d3058",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750991591,
-        "narHash": "sha256-X2x4rZKcQ8mUAfw+QH6i59z4IcucoVREg9U9IKhLqYE=",
+        "lastModified": 1752460810,
+        "narHash": "sha256-odwTzh0gJaveXmXIU1vE5URcY+ZX4t9KE6A3JCklrm4=",
         "owner": "nihirash",
         "repo": "rust-overlay",
-        "rev": "4e6646f6ad63ca51277feb983d1bee8855b860e6",
+        "rev": "a467f9ea2e3051064189aee416c0bd83b7a68fe4",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750931469,
-        "narHash": "sha256-0IEdQB1nS+uViQw4k3VGUXntjkDp7aAlqcxdewb/hAc=",
+        "lastModified": 1752055615,
+        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1",
+        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Rust cross-compilatilon utils";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     rust-overlay = {
       url = "github:nihirash/rust-overlay";
       inputs = {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -29,11 +29,6 @@ rec {
       # Some additional libraries for the Darwin platform
       ++ lib.optionals stdenv.isDarwin [
         libiconv
-        darwin.apple_sdk.frameworks.CoreFoundation
-        darwin.apple_sdk.frameworks.CoreServices
-        darwin.apple_sdk.frameworks.IOKit
-        darwin.apple_sdk.frameworks.Security
-        darwin.apple_sdk.frameworks.SystemConfiguration
       ])
     { };
 

--- a/lib/pkgs/utils/ldproxy.nix
+++ b/lib/pkgs/utils/ldproxy.nix
@@ -9,8 +9,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-XLfa40eMkeUL544gDqZYbly2E5Mrogn7v24D8u/wjkg=";
   };
 
-
-  cargoSha256 = "sha256-h7WOslRfu7cQ/af/b6C8gN2QrEt2SLxNnGeEv6bKj3E=";
+  cargoHash = "sha256-orWs8KYFUtMp5vbwhr3O13FGXjXXKZ6Idp+ZS538P+Y=";
 
   meta = with lib; {
     description = "A linker proxy tool";


### PR DESCRIPTION
With release of `rdkafka-sys` [4.9.0+2.10.0](https://crates.io/crates/rdkafka-sys/4.9.0+2.10.0) that version becomes a default one as a dependency of `rdkafka` crate. It requires 2.10.0 as minimal version of `librdkafka` that is not available in `nixos-24.11` and requires use of `nixos-25.05` 

Now deprecated `darwin.apple_sdk.frameworks` removed.